### PR TITLE
Convert 2d curve to 3d

### DIFF
--- a/CMakeLists_Curve2DTo3D.txt
+++ b/CMakeLists_Curve2DTo3D.txt
@@ -1,0 +1,123 @@
+# CMake configuration for Curve2DTo3DConverter
+cmake_minimum_required(VERSION 3.12)
+
+# Define the Curve2DTo3DConverter library
+set(Curve2DTo3DConverter_SOURCES
+  src/ModelingData/Curve2DTo3DConverter.cxx
+)
+
+set(Curve2DTo3DConverter_HEADERS
+  src/ModelingData/Curve2DTo3DConverter.h
+)
+
+# Create the library
+add_library(Curve2DTo3DConverter SHARED
+  ${Curve2DTo3DConverter_SOURCES}
+  ${Curve2DTo3DConverter_HEADERS}
+)
+
+# Set target properties
+set_target_properties(Curve2DTo3DConverter PROPERTIES
+  VERSION ${OCCT_VERSION}
+  SOVERSION ${OCCT_VERSION_MAJOR}
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED ON
+)
+
+# Include directories
+target_include_directories(Curve2DTo3DConverter PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/ModelingData>
+  $<INSTALL_INTERFACE:include/occt>
+)
+
+# Link with required OCCT libraries
+target_link_libraries(Curve2DTo3DConverter PUBLIC
+  TKernel          # Standard types and basic utilities
+  TKMath           # Mathematical functions
+  TKG2d            # 2D geometry
+  TKG3d            # 3D geometry
+  TKGeomBase       # Base geometry classes
+  TKBRep           # Boundary representation
+)
+
+# Set compile definitions
+target_compile_definitions(Curve2DTo3DConverter PRIVATE
+  $<$<CONFIG:Debug>:_DEBUG>
+  $<$<CONFIG:Release>:NDEBUG>
+)
+
+# Platform-specific settings
+if(WIN32)
+  target_compile_definitions(Curve2DTo3DConverter PRIVATE
+    WIN32
+    _WINDOWS
+    UNICODE
+    _UNICODE
+  )
+endif()
+
+# Export symbols for shared library
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(Curve2DTo3DConverter PRIVATE
+    "Curve2DTo3DConverter_EXPORTS"
+  )
+endif()
+
+# Example executable
+if(BUILD_EXAMPLES)
+  add_executable(Curve2DTo3DExample
+    examples/Curve2DTo3DExample.cpp
+  )
+  
+  target_link_libraries(Curve2DTo3DExample PRIVATE
+    Curve2DTo3DConverter
+    TKernel
+    TKMath
+    TKG2d
+    TKG3d
+    TKGeomBase
+    TKBRep
+  )
+  
+  # Copy to output directory
+  set_target_properties(Curve2DTo3DExample PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  )
+endif()
+
+# Installation rules
+install(TARGETS Curve2DTo3DConverter
+  EXPORT OCCTTargets
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(FILES ${Curve2DTo3DConverter_HEADERS}
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/occt
+)
+
+# Add to main OCCT targets if being included
+if(TARGET OCCT)
+  add_dependencies(OCCT Curve2DTo3DConverter)
+endif()
+
+# Testing (if enabled)
+if(BUILD_TESTING)
+  enable_testing()
+  
+  add_test(
+    NAME Curve2DTo3DConverter_BasicTest
+    COMMAND Curve2DTo3DExample
+  )
+  
+  set_tests_properties(Curve2DTo3DConverter_BasicTest PROPERTIES
+    TIMEOUT 30
+  )
+endif()
+
+# Documentation
+if(BUILD_DOC AND DOXYGEN_FOUND)
+  # Add to Doxygen documentation
+  set(DOXYGEN_INPUT ${DOXYGEN_INPUT} ${CMAKE_CURRENT_SOURCE_DIR}/src/ModelingData)
+endif()

--- a/docs/Curve2DTo3DConverter_README.md
+++ b/docs/Curve2DTo3DConverter_README.md
@@ -1,0 +1,282 @@
+# Curve2DTo3DConverter
+
+A comprehensive utility class for converting 2D curves to 3D curves in OpenCASCADE Technology (OCCT) applications.
+
+## Overview
+
+The `Curve2DTo3DConverter` class provides multiple methods to transform 2D parametric curves (`Geom2d_Curve`) into 3D curves (`Geom_Curve`) using various transformation approaches. This is particularly useful in CAD applications where you need to:
+
+- Place 2D sketches on arbitrary planes
+- Extrude 2D profiles into 3D space
+- Map curves onto surfaces
+- Create 3D geometry from 2D templates
+
+## Features
+
+### Supported 2D Curve Types
+
+The converter handles all standard OCCT 2D curve types with optimized conversions:
+
+- **Lines** (`Geom2d_Line`) → `Geom_Line`
+- **Circles** (`Geom2d_Circle`) → `Geom_Circle`
+- **Ellipses** (`Geom2d_Ellipse`) → `Geom_Ellipse`
+- **B-Splines** (`Geom2d_BSplineCurve`) → `Geom_BSplineCurve`
+- **Bézier curves** (`Geom2d_BezierCurve`) → `Geom_BezierCurve`
+- **Generic curves** → `Geom_BSplineCurve` (through sampling)
+
+### Conversion Methods
+
+#### 1. Plane-Based Conversion
+
+```cpp
+// Convert to XY plane (Z = 0)
+Handle(Geom_Curve) curve3d = converter.ConvertToXYPlane(curve2d);
+
+// Convert to custom plane
+gp_Pln customPlane(gp_Pnt(0,0,5), gp_Dir(0,0,1));
+Handle(Geom_Curve) curve3d = converter.ConvertToPlane(curve2d, customPlane);
+
+// Convert using coordinate system
+gp_Ax3 coordSystem(gp_Pnt(0,0,0), gp_Dir(0,0,1), gp_Dir(1,0,0));
+Handle(Geom_Curve) curve3d = converter.ConvertWithCoordSystem(curve2d, coordSystem);
+```
+
+#### 2. Extrusion-Based Conversion
+
+```cpp
+// Simple placement on XY plane
+Handle(Geom_Curve) curve3d = converter.ConvertWithExtrusion(curve2d, gp_Vec(0,0,1), 0.0);
+
+// Extrusion with offset
+gp_Vec direction(0, 0, 1);
+Standard_Real height = 10.0;
+Handle(Geom_Curve) curve3d = converter.ConvertWithExtrusion(curve2d, direction, height);
+```
+
+#### 3. Surface Mapping
+
+```cpp
+// Map 2D curve onto a surface
+Handle(Geom_Surface) surface = new Geom_CylindricalSurface(axis, radius);
+Handle(Geom_Curve) curve3d = converter.ConvertOnSurface(curve2d, surface);
+```
+
+#### 4. Transformation-Based Conversion
+
+```cpp
+// Apply custom transformation
+gp_Trsf transformation;
+transformation.SetRotation(axis, angle);
+Handle(Geom_Curve) curve3d = converter.ConvertWithTransformation(curve2d, transformation);
+```
+
+#### 5. Revolution
+
+```cpp
+// Revolve around an axis
+gp_Ax1 axis(gp_Pnt(0,0,0), gp_Dir(0,1,0));
+Standard_Real angle = M_PI / 2; // 90 degrees
+Handle(Geom_Curve) curve3d = converter.ConvertWithRevolution(curve2d, axis, angle);
+```
+
+## Usage Examples
+
+### Basic Line Conversion
+
+```cpp
+#include "Curve2DTo3DConverter.h"
+#include <Geom2d_Line.hxx>
+
+// Create a 2D line
+gp_Pnt2d origin(0.0, 0.0);
+gp_Dir2d direction(1.0, 1.0);
+Handle(Geom2d_Line) line2d = new Geom2d_Line(origin, direction);
+
+// Convert to 3D
+Curve2DTo3DConverter converter;
+Handle(Geom_Curve) line3d = converter.ConvertToXYPlane(line2d);
+
+// Use the 3D line
+gp_Pnt point = line3d->Value(5.0); // Point at parameter t=5
+```
+
+### Circle on Custom Plane
+
+```cpp
+// Create 2D circle
+gp_Ax2d ax2d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0));
+gp_Circ2d circle2d(ax2d, 5.0);
+Handle(Geom2d_Circle) geomCircle2d = new Geom2d_Circle(circle2d);
+
+// Define custom plane (45° rotation around X-axis)
+gp_Ax3 customCoordSystem(
+    gp_Pnt(0, 0, 0), 
+    gp_Dir(0, sin(M_PI/4), cos(M_PI/4)),
+    gp_Dir(1, 0, 0)
+);
+
+// Convert
+Curve2DTo3DConverter converter;
+Handle(Geom_Curve) circle3d = converter.ConvertWithCoordSystem(geomCircle2d, customCoordSystem);
+```
+
+### Helical Curve on Cylinder
+
+```cpp
+// Create 2D line (becomes helix when mapped to cylinder)
+gp_Pnt2d start(0.0, 0.0);
+gp_Pnt2d end(2*M_PI, 10.0); // One revolution, height 10
+gp_Dir2d dir((end.XY() - start.XY()).Normalized());
+Handle(Geom2d_Line) line2d = new Geom2d_Line(start, dir);
+
+// Create cylindrical surface
+gp_Ax3 cylinderAxis(gp_Pnt(0,0,0), gp_Dir(0,0,1), gp_Dir(1,0,0));
+Handle(Geom_CylindricalSurface) cylinder = new Geom_CylindricalSurface(cylinderAxis, 5.0);
+
+// Convert to helical curve
+Curve2DTo3DConverter converter;
+Handle(Geom_Curve) helix = converter.ConvertOnSurface(line2d, cylinder);
+```
+
+## Class Interface
+
+### Constructors
+
+```cpp
+// Default constructor (uses XY plane)
+Curve2DTo3DConverter();
+
+// Constructor with reference plane
+Curve2DTo3DConverter(const gp_Pln& thePlane);
+
+// Constructor with coordinate system
+Curve2DTo3DConverter(const gp_Ax3& theCoordSystem);
+```
+
+### Main Conversion Methods
+
+```cpp
+// Basic conversions
+Handle(Geom_Curve) ConvertToXYPlane(const Handle(Geom2d_Curve)& theCurve2D) const;
+Handle(Geom_Curve) ConvertToPlane(const Handle(Geom2d_Curve)& theCurve2D, const gp_Pln& thePlane) const;
+Handle(Geom_Curve) ConvertWithCoordSystem(const Handle(Geom2d_Curve)& theCurve2D, const gp_Ax3& theCoordSystem) const;
+
+// Advanced conversions
+Handle(Geom_Curve) ConvertWithExtrusion(const Handle(Geom2d_Curve)& theCurve2D, const gp_Vec& theDirection, const Standard_Real theHeight = 0.0) const;
+Handle(Geom_Curve) ConvertOnSurface(const Handle(Geom2d_Curve)& theCurve2D, const Handle(Geom_Surface)& theSurface) const;
+Handle(Geom_Curve) ConvertWithTransformation(const Handle(Geom2d_Curve)& theCurve2D, const gp_Trsf& theTransformation) const;
+Handle(Geom_Curve) ConvertWithRevolution(const Handle(Geom2d_Curve)& theCurve2D, const gp_Ax1& theAxis, const Standard_Real theAngle) const;
+```
+
+### Configuration Methods
+
+```cpp
+// Default settings
+void SetDefaultPlane(const gp_Pln& thePlane);
+const gp_Pln& GetDefaultPlane() const;
+void SetDefaultCoordSystem(const gp_Ax3& theCoordSystem);
+const gp_Ax3& GetDefaultCoordSystem() const;
+```
+
+## Building and Integration
+
+### CMake Integration
+
+The converter can be integrated into existing OCCT projects using the provided CMake configuration:
+
+```cmake
+# Include the converter
+include(CMakeLists_Curve2DTo3D.txt)
+
+# Link with your target
+target_link_libraries(your_target PRIVATE Curve2DTo3DConverter)
+```
+
+### Required Dependencies
+
+The converter depends on the following OCCT modules:
+
+- `TKernel` - Standard types and utilities
+- `TKMath` - Mathematical functions
+- `TKG2d` - 2D geometry classes
+- `TKG3d` - 3D geometry classes  
+- `TKGeomBase` - Base geometry classes
+- `TKBRep` - Boundary representation
+
+### Header Includes
+
+```cpp
+#include "Curve2DTo3DConverter.h"
+#include <Geom2d_Curve.hxx>    // For 2D curves
+#include <Geom_Curve.hxx>      // For 3D curves
+// Additional includes as needed for specific curve types
+```
+
+## Performance Considerations
+
+### Optimized Conversions
+
+The converter provides optimized paths for standard curve types:
+
+- **Analytical curves** (lines, circles, ellipses) are converted exactly
+- **B-splines and Bézier curves** preserve their mathematical representation
+- **Generic curves** are sampled and approximated with B-splines
+
+### Memory Management
+
+- All returned curves are managed by OCCT's handle system
+- Input curves are not modified during conversion
+- Memory is automatically managed through reference counting
+
+### Sampling Parameters
+
+For generic curves that require sampling:
+
+- Default: 100 sample points
+- Degree: 3 (cubic B-splines)
+- Smoothness: C2 continuity where possible
+
+## Error Handling
+
+The converter throws `Standard_NullObject` exceptions for null input parameters:
+
+```cpp
+try {
+    Handle(Geom_Curve) result = converter.ConvertToXYPlane(curve2d);
+} catch (const Standard_NullObject& e) {
+    std::cout << "Error: " << e.GetMessageString() << std::endl;
+}
+```
+
+## Common Use Cases
+
+### CAD Sketching
+- Convert 2D sketches to 3D for further modeling operations
+- Place profiles on construction planes
+
+### Surface Generation
+- Create 3D guide curves for surface creation
+- Map parametric curves onto complex surfaces
+
+### Manufacturing
+- Convert 2D tool paths to 3D machining paths
+- Transform profiles for extrusion operations
+
+### Visualization
+- Display 2D designs in 3D space
+- Create perspective views of planar geometry
+
+## Future Enhancements
+
+Potential areas for expansion:
+
+- Support for offset operations during conversion
+- Batch conversion of curve arrays
+- Integration with surface creation tools
+- Advanced approximation options for generic curves
+
+## See Also
+
+- [OpenCASCADE Geometry Documentation](https://dev.opencascade.org/doc/overview/html/occt_user_guides__modeling_data.html)
+- [2D Geometry Classes (Geom2d)](https://dev.opencascade.org/doc/refman/html/package_geom2d.html)
+- [3D Geometry Classes (Geom)](https://dev.opencascade.org/doc/refman/html/package_geom.html)

--- a/examples/Curve2DTo3DExample.cpp
+++ b/examples/Curve2DTo3DExample.cpp
@@ -1,0 +1,266 @@
+#include "Curve2DTo3DConverter.h"
+
+#include <Geom2d_Line.hxx>
+#include <Geom2d_Circle.hxx>
+#include <Geom2d_Ellipse.hxx>
+#include <Geom2d_BSplineCurve.hxx>
+#include <Geom2d_BezierCurve.hxx>
+
+#include <Geom_Plane.hxx>
+#include <Geom_CylindricalSurface.hxx>
+
+#include <gp_Pnt2d.hxx>
+#include <gp_Dir2d.hxx>
+#include <gp_Circ2d.hxx>
+#include <gp_Elips2d.hxx>
+#include <gp_Ax2d.hxx>
+
+#include <TColgp_Array1OfPnt2d.hxx>
+#include <TColStd_Array1OfReal.hxx>
+
+#include <iostream>
+
+void Example_ConvertLineToXYPlane()
+{
+  std::cout << "\n=== Converting 2D Line to 3D Line on XY Plane ===" << std::endl;
+  
+  // Create a 2D line from (0,0) with direction (1,1)
+  gp_Pnt2d origin2d(0.0, 0.0);
+  gp_Dir2d direction2d(1.0, 1.0);
+  Handle(Geom2d_Line) line2d = new Geom2d_Line(origin2d, direction2d);
+  
+  // Convert to 3D
+  Curve2DTo3DConverter converter;
+  Handle(Geom_Curve) line3d = converter.ConvertToXYPlane(line2d);
+  
+  // Test the conversion
+  gp_Pnt pt3d_start = line3d->Value(0.0);
+  gp_Pnt pt3d_end = line3d->Value(10.0);
+  
+  std::cout << "2D Line converted to 3D:" << std::endl;
+  std::cout << "Start point: (" << pt3d_start.X() << ", " << pt3d_start.Y() << ", " << pt3d_start.Z() << ")" << std::endl;
+  std::cout << "End point: (" << pt3d_end.X() << ", " << pt3d_end.Y() << ", " << pt3d_end.Z() << ")" << std::endl;
+}
+
+void Example_ConvertCircleToCustomPlane()
+{
+  std::cout << "\n=== Converting 2D Circle to 3D Circle on Custom Plane ===" << std::endl;
+  
+  // Create a 2D circle centered at (5,5) with radius 3
+  gp_Ax2d ax2d(gp_Pnt2d(5.0, 5.0), gp_Dir2d(1.0, 0.0));
+  gp_Circ2d circle2d(ax2d, 3.0);
+  Handle(Geom2d_Circle) geomCircle2d = new Geom2d_Circle(circle2d);
+  
+  // Create a custom plane (tilted 45 degrees around X axis)
+  gp_Ax3 customCoordSystem(gp_Pnt(0, 0, 10), 
+                          gp_Dir(0, M_PI/4, M_PI/4).Normalized(),
+                          gp_Dir(1, 0, 0));
+  gp_Pln customPlane(customCoordSystem);
+  
+  // Convert to 3D on custom plane
+  Curve2DTo3DConverter converter;
+  Handle(Geom_Curve) circle3d = converter.ConvertToPlane(geomCircle2d, customPlane);
+  
+  // Test points on the circle
+  std::cout << "2D Circle converted to 3D on custom plane:" << std::endl;
+  for (int i = 0; i < 4; i++)
+  {
+    Standard_Real param = i * M_PI / 2;
+    gp_Pnt pt = circle3d->Value(param);
+    std::cout << "Point " << i << ": (" << pt.X() << ", " << pt.Y() << ", " << pt.Z() << ")" << std::endl;
+  }
+}
+
+void Example_ConvertEllipseWithExtrusion()
+{
+  std::cout << "\n=== Converting 2D Ellipse with Extrusion ===" << std::endl;
+  
+  // Create a 2D ellipse
+  gp_Ax2d ax2d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0));
+  gp_Elips2d ellipse2d(ax2d, 5.0, 3.0); // Major radius 5, minor radius 3
+  Handle(Geom2d_Ellipse) geomEllipse2d = new Geom2d_Ellipse(ellipse2d);
+  
+  // Convert with extrusion along Z direction
+  Curve2DTo3DConverter converter;
+  gp_Vec extrusionDirection(0.0, 0.0, 1.0);
+  Standard_Real extrusionHeight = 10.0;
+  
+  Handle(Geom_Curve) ellipse3d = converter.ConvertWithExtrusion(
+    geomEllipse2d, extrusionDirection, extrusionHeight);
+  
+  // Test points on the ellipse
+  std::cout << "2D Ellipse converted to 3D with extrusion:" << std::endl;
+  for (int i = 0; i < 4; i++)
+  {
+    Standard_Real param = i * M_PI / 2;
+    gp_Pnt pt = ellipse3d->Value(param);
+    std::cout << "Point " << i << ": (" << pt.X() << ", " << pt.Y() << ", " << pt.Z() << ")" << std::endl;
+  }
+}
+
+void Example_ConvertBSplineCurve()
+{
+  std::cout << "\n=== Converting 2D B-Spline Curve ===" << std::endl;
+  
+  // Create a 2D B-spline curve
+  TColgp_Array1OfPnt2d poles2d(1, 4);
+  poles2d(1) = gp_Pnt2d(0.0, 0.0);
+  poles2d(2) = gp_Pnt2d(3.0, 4.0);
+  poles2d(3) = gp_Pnt2d(6.0, 2.0);
+  poles2d(4) = gp_Pnt2d(9.0, 0.0);
+  
+  TColStd_Array1OfReal knots(1, 2);
+  knots(1) = 0.0;
+  knots(2) = 1.0;
+  
+  TColStd_Array1OfInteger multiplicities(1, 2);
+  multiplicities(1) = 4;
+  multiplicities(2) = 4;
+  
+  Handle(Geom2d_BSplineCurve) bspline2d = new Geom2d_BSplineCurve(
+    poles2d, knots, multiplicities, 3);
+  
+  // Convert to 3D
+  Curve2DTo3DConverter converter;
+  Handle(Geom_Curve) bspline3d = converter.ConvertToXYPlane(bspline2d);
+  
+  // Test points along the curve
+  std::cout << "2D B-Spline converted to 3D:" << std::endl;
+  Standard_Real firstParam = bspline3d->FirstParameter();
+  Standard_Real lastParam = bspline3d->LastParameter();
+  
+  for (int i = 0; i <= 5; i++)
+  {
+    Standard_Real t = firstParam + i * (lastParam - firstParam) / 5.0;
+    gp_Pnt pt = bspline3d->Value(t);
+    std::cout << "Point " << i << " (t=" << t << "): (" 
+              << pt.X() << ", " << pt.Y() << ", " << pt.Z() << ")" << std::endl;
+  }
+}
+
+void Example_ConvertBezierCurve()
+{
+  std::cout << "\n=== Converting 2D Bezier Curve ===" << std::endl;
+  
+  // Create a 2D Bezier curve
+  TColgp_Array1OfPnt2d poles2d(1, 4);
+  poles2d(1) = gp_Pnt2d(0.0, 0.0);
+  poles2d(2) = gp_Pnt2d(1.0, 3.0);
+  poles2d(3) = gp_Pnt2d(4.0, 3.0);
+  poles2d(4) = gp_Pnt2d(5.0, 0.0);
+  
+  Handle(Geom2d_BezierCurve) bezier2d = new Geom2d_BezierCurve(poles2d);
+  
+  // Convert to 3D with transformation
+  Curve2DTo3DConverter converter;
+  
+  // Create a transformation (rotation around Y-axis)
+  gp_Trsf transformation;
+  gp_Ax1 yAxis(gp_Pnt(0,0,0), gp_Dir(0,1,0));
+  transformation.SetRotation(yAxis, M_PI / 4); // 45 degrees
+  
+  Handle(Geom_Curve) bezier3d = converter.ConvertWithTransformation(
+    bezier2d, transformation);
+  
+  // Test points along the curve
+  std::cout << "2D Bezier converted to 3D with rotation:" << std::endl;
+  for (int i = 0; i <= 5; i++)
+  {
+    Standard_Real t = i / 5.0;
+    gp_Pnt pt = bezier3d->Value(t);
+    std::cout << "Point " << i << " (t=" << t << "): (" 
+              << pt.X() << ", " << pt.Y() << ", " << pt.Z() << ")" << std::endl;
+  }
+}
+
+void Example_ConvertOnCylindricalSurface()
+{
+  std::cout << "\n=== Converting 2D Curve on Cylindrical Surface ===" << std::endl;
+  
+  // Create a 2D line (will become a helical curve on cylinder)
+  gp_Pnt2d start2d(0.0, 0.0);
+  gp_Pnt2d end2d(2*M_PI, 10.0); // One full revolution, height 10
+  gp_Dir2d direction2d = gp_Dir2d(end2d.XY() - start2d.XY());
+  Handle(Geom2d_Line) line2d = new Geom2d_Line(start2d, direction2d);
+  
+  // Create a cylindrical surface (radius 5, along Z-axis)
+  gp_Ax3 cylinderAxis(gp_Pnt(0,0,0), gp_Dir(0,0,1), gp_Dir(1,0,0));
+  Handle(Geom_CylindricalSurface) cylinderSurface = 
+    new Geom_CylindricalSurface(cylinderAxis, 5.0);
+  
+  // Convert 2D line to 3D curve on cylinder
+  Curve2DTo3DConverter converter;
+  Handle(Geom_Curve) helicalCurve = converter.ConvertOnSurface(line2d, cylinderSurface);
+  
+  // Test points along the helical curve
+  std::cout << "2D Line converted to helical curve on cylinder:" << std::endl;
+  Standard_Real firstParam = helicalCurve->FirstParameter();
+  Standard_Real lastParam = helicalCurve->LastParameter();
+  
+  for (int i = 0; i <= 5; i++)
+  {
+    Standard_Real t = firstParam + i * (lastParam - firstParam) / 5.0;
+    gp_Pnt pt = helicalCurve->Value(t);
+    std::cout << "Point " << i << ": (" 
+              << pt.X() << ", " << pt.Y() << ", " << pt.Z() << ")" << std::endl;
+  }
+}
+
+void Example_ConvertWithRevolution()
+{
+  std::cout << "\n=== Converting 2D Curve with Revolution ===" << std::endl;
+  
+  // Create a 2D circle that will be revolved
+  gp_Ax2d ax2d(gp_Pnt2d(3.0, 0.0), gp_Dir2d(1.0, 0.0)); // Circle at distance 3 from origin
+  gp_Circ2d circle2d(ax2d, 1.0); // Small circle with radius 1
+  Handle(Geom2d_Circle) geomCircle2d = new Geom2d_Circle(circle2d);
+  
+  // Revolve around Y-axis by 90 degrees
+  Curve2DTo3DConverter converter;
+  gp_Ax1 revolutionAxis(gp_Pnt(0,0,0), gp_Dir(0,1,0));
+  Standard_Real revolutionAngle = M_PI / 2; // 90 degrees
+  
+  Handle(Geom_Curve) revolvedCurve = converter.ConvertWithRevolution(
+    geomCircle2d, revolutionAxis, revolutionAngle);
+  
+  // Test points on the revolved curve
+  std::cout << "2D Circle revolved around Y-axis:" << std::endl;
+  for (int i = 0; i < 8; i++)
+  {
+    Standard_Real param = i * M_PI / 4;
+    gp_Pnt pt = revolvedCurve->Value(param);
+    std::cout << "Point " << i << ": (" 
+              << pt.X() << ", " << pt.Y() << ", " << pt.Z() << ")" << std::endl;
+  }
+}
+
+int main()
+{
+  std::cout << "2D to 3D Curve Conversion Examples" << std::endl;
+  std::cout << "===================================" << std::endl;
+  
+  try
+  {
+    Example_ConvertLineToXYPlane();
+    Example_ConvertCircleToCustomPlane();
+    Example_ConvertEllipseWithExtrusion();
+    Example_ConvertBSplineCurve();
+    Example_ConvertBezierCurve();
+    Example_ConvertOnCylindricalSurface();
+    Example_ConvertWithRevolution();
+    
+    std::cout << "\n=== All examples completed successfully! ===" << std::endl;
+  }
+  catch (const Standard_Failure& e)
+  {
+    std::cout << "Error: " << e.GetMessageString() << std::endl;
+    return 1;
+  }
+  catch (const std::exception& e)
+  {
+    std::cout << "Error: " << e.what() << std::endl;
+    return 1;
+  }
+  
+  return 0;
+}

--- a/src/ModelingData/Curve2DTo3DConverter.cxx
+++ b/src/ModelingData/Curve2DTo3DConverter.cxx
@@ -1,0 +1,390 @@
+#include "Curve2DTo3DConverter.h"
+
+#include <Geom2d_Curve.hxx>
+#include <Geom_Curve.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_Ellipse.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <Geom_BezierCurve.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <Geom_OffsetCurve.hxx>
+#include <Geom_SurfaceOfRevolution.hxx>
+#include <Geom_CurveOnSurface.hxx>
+
+#include <Geom2d_Line.hxx>
+#include <Geom2d_Circle.hxx>
+#include <Geom2d_Ellipse.hxx>
+#include <Geom2d_BSplineCurve.hxx>
+#include <Geom2d_BezierCurve.hxx>
+#include <Geom2d_TrimmedCurve.hxx>
+
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Dir2d.hxx>
+#include <gp_Ax1.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Elips.hxx>
+#include <gp_Lin.hxx>
+
+#include <TColgp_Array1OfPnt.hxx>
+#include <TColStd_Array1OfReal.hxx>
+#include <TColStd_Array1OfInteger.hxx>
+
+#include <GeomAdaptor_Surface.hxx>
+#include <Adaptor3d_CurveOnSurface.hxx>
+
+#include <Standard_ConstructionError.hxx>
+#include <Standard_NullObject.hxx>
+
+//=======================================================================
+//function : Curve2DTo3DConverter
+//purpose  : Default constructor
+//=======================================================================
+Curve2DTo3DConverter::Curve2DTo3DConverter()
+: myDefaultPlane(gp_Pln(gp_Pnt(0,0,0), gp_Dir(0,0,1))),
+  myDefaultCoordSystem(gp_Ax3(gp_Pnt(0,0,0), gp_Dir(0,0,1), gp_Dir(1,0,0)))
+{
+}
+
+//=======================================================================
+//function : Curve2DTo3DConverter
+//purpose  : Constructor with reference plane
+//=======================================================================
+Curve2DTo3DConverter::Curve2DTo3DConverter(const gp_Pln& thePlane)
+: myDefaultPlane(thePlane),
+  myDefaultCoordSystem(thePlane.Position())
+{
+}
+
+//=======================================================================
+//function : Curve2DTo3DConverter
+//purpose  : Constructor with coordinate system
+//=======================================================================
+Curve2DTo3DConverter::Curve2DTo3DConverter(const gp_Ax3& theCoordSystem)
+: myDefaultPlane(gp_Pln(theCoordSystem)),
+  myDefaultCoordSystem(theCoordSystem)
+{
+}
+
+//=======================================================================
+//function : ~Curve2DTo3DConverter
+//purpose  : Destructor
+//=======================================================================
+Curve2DTo3DConverter::~Curve2DTo3DConverter()
+{
+}
+
+//=======================================================================
+//function : ConvertToXYPlane
+//purpose  : Convert 2D curve to 3D on XY plane
+//=======================================================================
+Handle(Geom_Curve) Curve2DTo3DConverter::ConvertToXYPlane(
+  const Handle(Geom2d_Curve)& theCurve2D) const
+{
+  if (theCurve2D.IsNull())
+    throw Standard_NullObject("Curve2DTo3DConverter::ConvertToXYPlane - null input curve");
+
+  gp_Pln xyPlane(gp_Pnt(0,0,0), gp_Dir(0,0,1));
+  return ConvertToPlane(theCurve2D, xyPlane);
+}
+
+//=======================================================================
+//function : ConvertToPlane
+//purpose  : Convert 2D curve to 3D on specified plane
+//=======================================================================
+Handle(Geom_Curve) Curve2DTo3DConverter::ConvertToPlane(
+  const Handle(Geom2d_Curve)& theCurve2D,
+  const gp_Pln& thePlane) const
+{
+  if (theCurve2D.IsNull())
+    throw Standard_NullObject("Curve2DTo3DConverter::ConvertToPlane - null input curve");
+
+  return ConvertWithCoordSystem(theCurve2D, thePlane.Position());
+}
+
+//=======================================================================
+//function : ConvertWithCoordSystem
+//purpose  : Convert 2D curve to 3D using coordinate system
+//=======================================================================
+Handle(Geom_Curve) Curve2DTo3DConverter::ConvertWithCoordSystem(
+  const Handle(Geom2d_Curve)& theCurve2D,
+  const gp_Ax3& theCoordSystem) const
+{
+  if (theCurve2D.IsNull())
+    throw Standard_NullObject("Curve2DTo3DConverter::ConvertWithCoordSystem - null input curve");
+
+  Handle(Geom_Curve) result;
+  
+  // Handle specific curve types for better performance and accuracy
+  if (Handle(Geom2d_Line) line2d = Handle(Geom2d_Line)::DownCast(theCurve2D))
+  {
+    gp_Pnt2d pt2d = line2d->Location();
+    gp_Dir2d dir2d = line2d->Direction();
+    
+    gp_Pnt pt3d = theCoordSystem.Location().XYZ() + 
+                  pt2d.X() * theCoordSystem.XDirection().XYZ() +
+                  pt2d.Y() * theCoordSystem.YDirection().XYZ();
+    
+    gp_Dir dir3d(dir2d.X() * theCoordSystem.XDirection().XYZ() +
+                 dir2d.Y() * theCoordSystem.YDirection().XYZ());
+    
+    result = new Geom_Line(pt3d, dir3d);
+  }
+  else if (Handle(Geom2d_Circle) circle2d = Handle(Geom2d_Circle)::DownCast(theCurve2D))
+  {
+    gp_Circ2d circ2d = circle2d->Circ2d();
+    gp_Pnt2d center2d = circ2d.Location();
+    Standard_Real radius = circ2d.Radius();
+    
+    gp_Pnt center3d = theCoordSystem.Location().XYZ() + 
+                      center2d.X() * theCoordSystem.XDirection().XYZ() +
+                      center2d.Y() * theCoordSystem.YDirection().XYZ();
+    
+    gp_Ax2 ax2(center3d, theCoordSystem.Direction(), theCoordSystem.XDirection());
+    gp_Circ circ3d(ax2, radius);
+    
+    result = new Geom_Circle(circ3d);
+  }
+  else if (Handle(Geom2d_Ellipse) ellipse2d = Handle(Geom2d_Ellipse)::DownCast(theCurve2D))
+  {
+    gp_Elips2d elips2d = ellipse2d->Elips2d();
+    gp_Pnt2d center2d = elips2d.Location();
+    Standard_Real majorRadius = elips2d.MajorRadius();
+    Standard_Real minorRadius = elips2d.MinorRadius();
+    
+    gp_Pnt center3d = theCoordSystem.Location().XYZ() + 
+                      center2d.X() * theCoordSystem.XDirection().XYZ() +
+                      center2d.Y() * theCoordSystem.YDirection().XYZ();
+    
+    gp_Ax2 ax2(center3d, theCoordSystem.Direction(), theCoordSystem.XDirection());
+    gp_Elips elips3d(ax2, majorRadius, minorRadius);
+    
+    result = new Geom_Ellipse(elips3d);
+  }
+  else if (Handle(Geom2d_BSplineCurve) bspline2d = Handle(Geom2d_BSplineCurve)::DownCast(theCurve2D))
+  {
+    Standard_Integer nbPoles = bspline2d->NbPoles();
+    TColgp_Array1OfPnt poles3d(1, nbPoles);
+    
+    for (Standard_Integer i = 1; i <= nbPoles; i++)
+    {
+      gp_Pnt2d pole2d = bspline2d->Pole(i);
+      gp_Pnt pole3d = theCoordSystem.Location().XYZ() + 
+                      pole2d.X() * theCoordSystem.XDirection().XYZ() +
+                      pole2d.Y() * theCoordSystem.YDirection().XYZ();
+      poles3d(i) = pole3d;
+    }
+    
+    TColStd_Array1OfReal weights(1, nbPoles);
+    for (Standard_Integer i = 1; i <= nbPoles; i++)
+    {
+      weights(i) = bspline2d->Weight(i);
+    }
+    
+    Standard_Integer nbKnots = bspline2d->NbKnots();
+    TColStd_Array1OfReal knots(1, nbKnots);
+    TColStd_Array1OfInteger multiplicities(1, nbKnots);
+    
+    for (Standard_Integer i = 1; i <= nbKnots; i++)
+    {
+      knots(i) = bspline2d->Knot(i);
+      multiplicities(i) = bspline2d->Multiplicity(i);
+    }
+    
+    result = new Geom_BSplineCurve(poles3d, weights, knots, multiplicities, bspline2d->Degree());
+  }
+  else if (Handle(Geom2d_BezierCurve) bezier2d = Handle(Geom2d_BezierCurve)::DownCast(theCurve2D))
+  {
+    Standard_Integer nbPoles = bezier2d->NbPoles();
+    TColgp_Array1OfPnt poles3d(1, nbPoles);
+    
+    for (Standard_Integer i = 1; i <= nbPoles; i++)
+    {
+      gp_Pnt2d pole2d = bezier2d->Pole(i);
+      gp_Pnt pole3d = theCoordSystem.Location().XYZ() + 
+                      pole2d.X() * theCoordSystem.XDirection().XYZ() +
+                      pole2d.Y() * theCoordSystem.YDirection().XYZ();
+      poles3d(i) = pole3d;
+    }
+    
+    if (bezier2d->IsRational())
+    {
+      TColStd_Array1OfReal weights(1, nbPoles);
+      for (Standard_Integer i = 1; i <= nbPoles; i++)
+      {
+        weights(i) = bezier2d->Weight(i);
+      }
+      result = new Geom_BezierCurve(poles3d, weights);
+    }
+    else
+    {
+      result = new Geom_BezierCurve(poles3d);
+    }
+  }
+  else
+  {
+    // Generic approach: sample points and create B-spline
+    Standard_Integer nbSamples = 100;
+    Standard_Real uFirst = theCurve2D->FirstParameter();
+    Standard_Real uLast = theCurve2D->LastParameter();
+    
+    TColgp_Array1OfPnt points3d(1, nbSamples);
+    Standard_Real du = (uLast - uFirst) / (nbSamples - 1);
+    
+    for (Standard_Integer i = 1; i <= nbSamples; i++)
+    {
+      Standard_Real u = uFirst + (i - 1) * du;
+      gp_Pnt2d pt2d = theCurve2D->Value(u);
+      gp_Pnt pt3d = theCoordSystem.Location().XYZ() + 
+                    pt2d.X() * theCoordSystem.XDirection().XYZ() +
+                    pt2d.Y() * theCoordSystem.YDirection().XYZ();
+      points3d(i) = pt3d;
+    }
+    
+    // Create B-spline through points (simplified approach)
+    result = new Geom_BSplineCurve(points3d, 3, 8);
+  }
+  
+  return result;
+}
+
+//=======================================================================
+//function : ConvertWithExtrusion
+//purpose  : Convert 2D curve to 3D with extrusion
+//=======================================================================
+Handle(Geom_Curve) Curve2DTo3DConverter::ConvertWithExtrusion(
+  const Handle(Geom2d_Curve)& theCurve2D,
+  const gp_Vec& theDirection,
+  const Standard_Real theHeight) const
+{
+  if (theCurve2D.IsNull())
+    throw Standard_NullObject("Curve2DTo3DConverter::ConvertWithExtrusion - null input curve");
+
+  Handle(Geom_Curve) baseCurve = ConvertToXYPlane(theCurve2D);
+  
+  if (Abs(theHeight) > Precision::Confusion())
+  {
+    gp_Trsf translation;
+    translation.SetTranslation(theDirection.Normalized() * theHeight);
+    baseCurve->Transform(translation);
+  }
+  
+  return baseCurve;
+}
+
+//=======================================================================
+//function : ConvertOnSurface
+//purpose  : Convert 2D curve to 3D on surface
+//=======================================================================
+Handle(Geom_Curve) Curve2DTo3DConverter::ConvertOnSurface(
+  const Handle(Geom2d_Curve)& theCurve2D,
+  const Handle(Geom_Surface)& theSurface) const
+{
+  if (theCurve2D.IsNull() || theSurface.IsNull())
+    throw Standard_NullObject("Curve2DTo3DConverter::ConvertOnSurface - null input");
+
+  Handle(GeomAdaptor_Surface) surfaceAdaptor = new GeomAdaptor_Surface(theSurface);
+  Handle(Adaptor3d_CurveOnSurface) curveOnSurface = 
+    new Adaptor3d_CurveOnSurface(theCurve2D, surfaceAdaptor);
+  
+  // Sample points on the surface
+  Standard_Integer nbSamples = 100;
+  Standard_Real uFirst = theCurve2D->FirstParameter();
+  Standard_Real uLast = theCurve2D->LastParameter();
+  
+  TColgp_Array1OfPnt points3d(1, nbSamples);
+  Standard_Real du = (uLast - uFirst) / (nbSamples - 1);
+  
+  for (Standard_Integer i = 1; i <= nbSamples; i++)
+  {
+    Standard_Real u = uFirst + (i - 1) * du;
+    gp_Pnt2d pt2d = theCurve2D->Value(u);
+    gp_Pnt pt3d = theSurface->Value(pt2d.X(), pt2d.Y());
+    points3d(i) = pt3d;
+  }
+  
+  return new Geom_BSplineCurve(points3d, 3, 8);
+}
+
+//=======================================================================
+//function : ConvertWithTransformation
+//purpose  : Convert 2D curve to 3D using transformation
+//=======================================================================
+Handle(Geom_Curve) Curve2DTo3DConverter::ConvertWithTransformation(
+  const Handle(Geom2d_Curve)& theCurve2D,
+  const gp_Trsf& theTransformation) const
+{
+  if (theCurve2D.IsNull())
+    throw Standard_NullObject("Curve2DTo3DConverter::ConvertWithTransformation - null input curve");
+
+  Handle(Geom_Curve) curve3d = ConvertToXYPlane(theCurve2D);
+  curve3d->Transform(theTransformation);
+  
+  return curve3d;
+}
+
+//=======================================================================
+//function : ConvertWithRevolution
+//purpose  : Convert 2D curve to 3D by revolution
+//=======================================================================
+Handle(Geom_Curve) Curve2DTo3DConverter::ConvertWithRevolution(
+  const Handle(Geom2d_Curve)& theCurve2D,
+  const gp_Ax1& theAxis,
+  const Standard_Real theAngle) const
+{
+  if (theCurve2D.IsNull())
+    throw Standard_NullObject("Curve2DTo3DConverter::ConvertWithRevolution - null input curve");
+
+  // For revolution, we typically want to create a surface of revolution
+  // and then extract a curve from it. For simplicity, we'll rotate the curve
+  // by the specified angle around the axis.
+  
+  Handle(Geom_Curve) baseCurve = ConvertToXYPlane(theCurve2D);
+  
+  gp_Trsf rotation;
+  rotation.SetRotation(theAxis, theAngle);
+  baseCurve->Transform(rotation);
+  
+  return baseCurve;
+}
+
+//=======================================================================
+//function : SetDefaultPlane
+//purpose  : Set default plane
+//=======================================================================
+void Curve2DTo3DConverter::SetDefaultPlane(const gp_Pln& thePlane)
+{
+  myDefaultPlane = thePlane;
+  myDefaultCoordSystem = thePlane.Position();
+}
+
+//=======================================================================
+//function : GetDefaultPlane
+//purpose  : Get default plane
+//=======================================================================
+const gp_Pln& Curve2DTo3DConverter::GetDefaultPlane() const
+{
+  return myDefaultPlane;
+}
+
+//=======================================================================
+//function : SetDefaultCoordSystem
+//purpose  : Set default coordinate system
+//=======================================================================
+void Curve2DTo3DConverter::SetDefaultCoordSystem(const gp_Ax3& theCoordSystem)
+{
+  myDefaultCoordSystem = theCoordSystem;
+  myDefaultPlane = gp_Pln(theCoordSystem);
+}
+
+//=======================================================================
+//function : GetDefaultCoordSystem
+//purpose  : Get default coordinate system
+//=======================================================================
+const gp_Ax3& Curve2DTo3DConverter::GetDefaultCoordSystem() const
+{
+  return myDefaultCoordSystem;
+}

--- a/src/ModelingData/Curve2DTo3DConverter.h
+++ b/src/ModelingData/Curve2DTo3DConverter.h
@@ -1,0 +1,117 @@
+#ifndef _Curve2DTo3DConverter_HeaderFile
+#define _Curve2DTo3DConverter_HeaderFile
+
+#include <Standard.hxx>
+#include <Standard_DefineAlloc.hxx>
+#include <Standard_Handle.hxx>
+
+#include <Geom2d_Curve.hxx>
+#include <Geom_Curve.hxx>
+#include <Geom_Surface.hxx>
+#include <gp_Pln.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Trsf.hxx>
+#include <gp_Vec.hxx>
+
+//! This class provides methods to convert 2D curves to 3D curves
+//! using various transformation approaches
+class Curve2DTo3DConverter
+{
+public:
+
+  DEFINE_STANDARD_ALLOC
+
+  //! Default constructor
+  Standard_EXPORT Curve2DTo3DConverter();
+
+  //! Constructor with a reference plane
+  Standard_EXPORT Curve2DTo3DConverter(const gp_Pln& thePlane);
+
+  //! Constructor with a coordinate system
+  Standard_EXPORT Curve2DTo3DConverter(const gp_Ax3& theCoordSystem);
+
+  //! Destructor
+  Standard_EXPORT ~Curve2DTo3DConverter();
+
+public:
+
+  //! Convert a 2D curve to 3D by placing it on the XY plane (Z=0)
+  //! @param theCurve2D the input 2D curve
+  //! @return the resulting 3D curve
+  Standard_EXPORT Handle(Geom_Curve) ConvertToXYPlane(
+    const Handle(Geom2d_Curve)& theCurve2D) const;
+
+  //! Convert a 2D curve to 3D by placing it on a specified plane
+  //! @param theCurve2D the input 2D curve
+  //! @param thePlane the target plane
+  //! @return the resulting 3D curve
+  Standard_EXPORT Handle(Geom_Curve) ConvertToPlane(
+    const Handle(Geom2d_Curve)& theCurve2D,
+    const gp_Pln& thePlane) const;
+
+  //! Convert a 2D curve to 3D using a coordinate system
+  //! @param theCurve2D the input 2D curve
+  //! @param theCoordSystem the target coordinate system
+  //! @return the resulting 3D curve
+  Standard_EXPORT Handle(Geom_Curve) ConvertWithCoordSystem(
+    const Handle(Geom2d_Curve)& theCurve2D,
+    const gp_Ax3& theCoordSystem) const;
+
+  //! Convert a 2D curve to 3D by extruding along a direction
+  //! @param theCurve2D the input 2D curve
+  //! @param theDirection the extrusion direction
+  //! @param theHeight the extrusion height (creates a line if > 0)
+  //! @return the resulting 3D curve (original curve + translation)
+  Standard_EXPORT Handle(Geom_Curve) ConvertWithExtrusion(
+    const Handle(Geom2d_Curve)& theCurve2D,
+    const gp_Vec& theDirection,
+    const Standard_Real theHeight = 0.0) const;
+
+  //! Convert a 2D curve to 3D by mapping it onto a surface
+  //! @param theCurve2D the input 2D curve
+  //! @param theSurface the target surface
+  //! @return the resulting 3D curve on the surface
+  Standard_EXPORT Handle(Geom_Curve) ConvertOnSurface(
+    const Handle(Geom2d_Curve)& theCurve2D,
+    const Handle(Geom_Surface)& theSurface) const;
+
+  //! Convert a 2D curve to 3D using a transformation matrix
+  //! @param theCurve2D the input 2D curve
+  //! @param theTransformation the transformation matrix
+  //! @return the resulting 3D curve
+  Standard_EXPORT Handle(Geom_Curve) ConvertWithTransformation(
+    const Handle(Geom2d_Curve)& theCurve2D,
+    const gp_Trsf& theTransformation) const;
+
+  //! Convert a 2D curve to 3D by revolution around an axis
+  //! @param theCurve2D the input 2D curve
+  //! @param theAxis the revolution axis
+  //! @param theAngle the revolution angle in radians
+  //! @return the resulting 3D curve
+  Standard_EXPORT Handle(Geom_Curve) ConvertWithRevolution(
+    const Handle(Geom2d_Curve)& theCurve2D,
+    const gp_Ax1& theAxis,
+    const Standard_Real theAngle) const;
+
+public:
+
+  //! Set the default plane for conversion
+  Standard_EXPORT void SetDefaultPlane(const gp_Pln& thePlane);
+
+  //! Get the default plane
+  Standard_EXPORT const gp_Pln& GetDefaultPlane() const;
+
+  //! Set the default coordinate system for conversion
+  Standard_EXPORT void SetDefaultCoordSystem(const gp_Ax3& theCoordSystem);
+
+  //! Get the default coordinate system
+  Standard_EXPORT const gp_Ax3& GetDefaultCoordSystem() const;
+
+private:
+
+  gp_Pln myDefaultPlane;        //!< Default plane for conversion
+  gp_Ax3 myDefaultCoordSystem;  //!< Default coordinate system
+
+};
+
+#endif // _Curve2DTo3DConverter_HeaderFile


### PR DESCRIPTION
Adds a `Curve2DTo3DConverter` class to enable versatile conversion of 2D curves into 3D geometry.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bfb736a-6432-4a1c-b213-754827c4f24b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0bfb736a-6432-4a1c-b213-754827c4f24b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

